### PR TITLE
Add Not Human Search to AI Citation & Visibility Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | **seoClarity** | AI-powered platform with GEO analytics module for enterprise content optimization | [seoclarity.net](https://www.seoclarity.net) |
 | **Botify** | Enterprise SEO platform with AI search readiness scoring and crawl optimization | [botify.com](https://www.botify.com) |
 | **Foglift** | AI-powered GEO readiness scanner analyzing llms.txt, structured data, crawlability, and AI search visibility. Free scan with API and MCP server | [foglift.io](https://foglift.io) |
+| **Not Human Search** | Open-source GEO scorer. Scores any URL across 7 agentic-readiness signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Public index of 8,000+ already-scored sites. Free REST API, MCP server, embeddable SVG badges, and a GitHub Action for CI. MIT | [nothumansearch.ai](https://nothumansearch.ai) |
 
 
 ## AI Search Engines


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/) to the **AI Citation & Visibility Analytics** table.

Direct peer to Foglift (already listed right above it) — both are GEO readiness scanners. Differentiator: NHS is **open-source** (MIT) with a transparent 7-signal rubric, whereas most entries in this table are closed-source dashboards.

- Scores any URL across 7 agentic readiness signals
- Public index of 8,000+ already-scored sites (queryable via REST or MCP)
- Embeddable shields.io-style SVG badges at `/badge/{domain}.svg`
- Free GitHub Action: [unitedideas/nhs-score-check-action](https://github.com/unitedideas/nhs-score-check-action)
- Source: https://github.com/unitedideas/nothumansearch (MIT)