### PR TITLE
Add Parse to AI Search Engine Monitoring tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | **WorkDuo.ai**     | Best for quick implementation for teams new to AI search optimization                                                                           | [workduo.ai](https://workduo.ai)                 |
 | **Quattr**         | Execution-focused SEO platform that connects traditional search performance with emerging AI visibility signals                                 | [quattr.com](https://quattr.com)                 |
 | **Surfeo**         | AI-powered GEO platform for SMBs; tracks brand visibility across ChatGPT, Gemini, Perplexity & Claude with content generation, audits, and scoring | [surfeo.ai](https://surfeo.ai)                   |
+| **Parse**          | AI brand visibility analytics tracking ChatGPT and Google AI Overviews; Parse Score benchmarks, citation diagnostics, competitor battlecards, and 577K+ brands tracked | [parse.gl](https://parse.gl)                     |
 
 ### Content Optimization Tools
 


### PR DESCRIPTION
Adds [Parse](https://parse.gl) to the AI Search Engine Monitoring table.

Parse tracks how brands appear in ChatGPT and Google AI Overviews, with daily updates across 577,000+ brands. Each brand gets a Parse Score (composite of recommendation frequency, citation share, and competitor positioning), a competitor battlecard, and a citation diagnostic feed. Free brand search is open to anyone.

Sits naturally alongside Profound, Otterly.AI, and Peec AI in the same row of the GEO landscape.

Format-matched to the existing table (bold name, description, link); appended at the bottom of the section per CONTRIBUTING.md.