### PR TITLE
Add Arenza to AI Search Engine Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | **WorkDuo.ai**     | Best for quick implementation for teams new to AI search optimization                                                                           | [workduo.ai](https://workduo.ai)                 |
 | **Quattr**         | Execution-focused SEO platform that connects traditional search performance with emerging AI visibility signals                                 | [quattr.com](https://quattr.com)                 |
 | **Surfeo**         | AI-powered GEO platform for SMBs; tracks brand visibility across ChatGPT, Gemini, Perplexity & Claude with content generation, audits, and scoring | [surfeo.ai](https://surfeo.ai)                   |
+| **Arenza**         | AI visibility platform for agencies and brands tracking mentions, sentiment, and share of voice across ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok | [arenza.ai](https://arenza.ai)                   |
 
 ### Content Optimization Tools
 


### PR DESCRIPTION
Adds Arenza to the AI Search Engine Monitoring section under Tools & Platforms.

Arenza is an AI visibility platform that tracks brand mentions, sentiment, and share of voice across ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok — fitting alongside existing entries like Profound, Otterly.AI, Peec AI, and Surfeo.

Project links:
- Website: https://arenza.ai
- Docs: https://arenza.ai/guides

Placed at the end of the section following the existing entry style. Single-line table row, no promotional language.