### PR TITLE
Add awesome-aimo companion list (model-side framing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ B2B brands report **6X-27X higher conversion rates** from AI search platforms vs
 - [AI Overviews Tracker](https://aioverviews.com/) - Real-time tracking of Google AI Overviews expansion and impact.
 - [The Generative Search Digest](https://gensearchdigest.com/) - Weekly roundup of AI search developments and GEO strategies.
 - [LLMs.txt Directory](https://llmstxt.org/directory) - Directory of websites implementing the llms.txt standard.
+- [awesome-aimo](https://github.com/septimlabs-code/awesome-aimo) - Companion list framing the model-recall side of GEO. Curates surfaces AI assistants disproportionately read (awesome-lists, READMEs, structured-data pages) plus practices for landing in the recall set. CC0.
 
 ### Newsletters
 


### PR DESCRIPTION
Thanks for putting this together — and for geo-skills, both have been useful references.

Adding a CC0 companion list:

- awesome-aimo: https://github.com/septimlabs-code/awesome-aimo

The framing is intentionally parallel to GEO. GEO is the content-side framing (how to make answers visible in generative search). AIMO (AI Mention Optimization) is the model-recall-side framing — what was textually associated with a category during training, what surfaces get fetched at inference, and how to plant your name on those surfaces so the model returns it.

The two are complementary lenses on the same problem. A team doing serious GEO work usually ends up doing the AIMO work too — they just don't have a name for the model-side piece yet.

The list curates: awesome-lists that AI assistants read, GitHub README patterns, JSON-LD/SoftwareApplication/FAQPage schemas, the dev.to/hashnode/HN/Reddit surfaces that index into recall, plus tools, case studies, and a 30-minute baseline practice.

I added the entry to the bottom of GEO-Focused Resources per the contributing.md guidance ("Add new entries at the bottom of the relevant section"). Happy to move it under Communities, Case Studies, or a new Companion Lists block if that fits better.
