### PR TITLE
Add auto-geo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | **seoClarity** | AI-powered platform with GEO analytics module for enterprise content optimization | [seoclarity.net](https://www.seoclarity.net) |
 | **Botify** | Enterprise SEO platform with AI search readiness scoring and crawl optimization | [botify.com](https://www.botify.com) |
 | **Foglift** | AI-powered GEO readiness scanner analyzing llms.txt, structured data, crawlability, and AI search visibility. Free scan with API and MCP server | [foglift.io](https://foglift.io) |
+| **auto-geo** | Open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain | [github.com/shadowresearch/auto-geo](https://github.com/shadowresearch/auto-geo) |
 
 
 ## AI Search Engines


### PR DESCRIPTION
auto-geo is an open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain.

Disclosure: I work on auto-geo at Shadow.

The project is MIT-licensed and open source: https://github.com/shadowresearch/auto-geo

Added at the bottom of the AI Citation & Visibility Analytics table per the contributing guidelines.