### PR TITLE
Add GEODoctor — open-source evidence-backed GEO audit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 
 | Tool                | Description                                                                                                                         | Link                                             |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **GEODoctor**       | Open-source GEO audit CLI — `npx geo-doctor audit yoursite.com` scores 33 evidence-backed rules across machine access, structure, chunkability, citability & freshness; every rule cites public research; bilingual EN/中文; no API key | [github.com/LJMStark/geo-doctor](https://github.com/LJMStark/geo-doctor) |
 | **Clearscope**      | AI-powered content optimization platform                                                                                            | [clearscope.io](https://clearscope.io)           |
 | **Surfer SEO**      | Content optimization and SERP analysis                                                                                              | [surferseo.com](https://surferseo.com)           |
 | **MarketMuse**      | AI content strategy platform                                                                                                        | [marketmuse.com](https://marketmuse.com)         |


### PR DESCRIPTION
Adds **GEODoctor** to *Tools & Platforms → Content Optimization Tools*.

- Open source (Apache-2.0), one command, no API key: `npx geo-doctor audit yoursite.com`
- 33 audit rules, each citing public research (KDD'24 GEO paper, arXiv:2604.25707 citation-absorption study, Vercel AI-crawler measurements, llms.txt spec) — rule×evidence table: [methodology](https://github.com/LJMStark/geo-doctor/blob/main/docs/methodology.md)
- 0-100 GEO Score across 5 dimensions, terminal + shareable HTML + JSON reports, bilingual EN/中文
- Reproducible [11-site leaderboard](https://github.com/LJMStark/geo-doctor/blob/main/docs/showcase.md)

One table row added, matching existing format. Thanks!