### PR TITLE
Add Citeable to Structured Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 | **Google Rich Results Test** | Test structured data                                    | [Google Tool](https://search.google.com/test/rich-results)                  |
 | **Schema Markup Generator**  | Structured data generator                               | [technicalseo.com](https://technicalseo.com/tools/schema-markup-generator/) |
 | **Schema Pro**               | WordPress plugin for automated Schema markup generation | [wpschema.com](https://wpschema.com)                                        |
+| **Citeable**                 | Generates llms.txt, llms-full.txt and Q&A schema.org (JSON-LD) markup from a site's content to make it citable by AI answer engines | [citeable.eu](https://citeable.eu)                                          |
 
 ### AI Citation & Visibility Analytics
 


### PR DESCRIPTION
Adds **Citeable** ([citeable.eu](https://citeable.eu)) to the list.

Citeable is a Generative Engine Optimization tool: you paste a site URL, it crawls the public pages and generates an `llms.txt`, an `llms-full.txt`, and Q&A `schema.org` markup (JSON-LD) that make the site readable and citable by AI answer engines (ChatGPT, Perplexity, Gemini, Claude). It also dogfoods its own output at https://citeable.eu/llms.txt and https://citeable.eu/llms-full.txt.

- Live and usable (free citability scan; one-time payment for generation).
- Single entry, placed in the most relevant section, matching the existing format.