### PR TITLE
Add Rankfor.AI (AI visibility platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | **WorkDuo.ai**     | Best for quick implementation for teams new to AI search optimization                                                                           | [workduo.ai](https://workduo.ai)                 |
 | **Quattr**         | Execution-focused SEO platform that connects traditional search performance with emerging AI visibility signals                                 | [quattr.com](https://quattr.com)                 |
 | **Surfeo**         | AI-powered GEO platform for SMBs; tracks brand visibility across ChatGPT, Gemini, Perplexity & Claude with content generation, audits, and scoring | [surfeo.ai](https://surfeo.ai)                   |
+| **Rankfor.AI**     | European AI visibility and reputation platform; measures how ChatGPT, Gemini, Claude and Perplexity recommend a brand, checks cross-model consistency, and generates content to close gaps; GDPR and EU AI Act aligned | [rankfor.ai](https://rankfor.ai)                 |
 
 ### Content Optimization Tools
 


### PR DESCRIPTION
Adds a table row for Rankfor.AI under Tools & Platforms → AI Search Engine Monitoring, matching the existing row format.

Rankfor.AI is a European AI visibility platform: it measures how ChatGPT, Gemini, Claude and Perplexity describe and recommend a brand, checks cross-model consistency, and generates content to close gaps. Site: https://rankfor.ai.