### PR TITLE
Add shopify-geo-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | **seoClarity** | AI-powered platform with GEO analytics module for enterprise content optimization | [seoclarity.net](https://www.seoclarity.net) |
 | **Botify** | Enterprise SEO platform with AI search readiness scoring and crawl optimization | [botify.com](https://www.botify.com) |
 | **Foglift** | AI-powered GEO readiness scanner analyzing llms.txt, structured data, crawlability, and AI search visibility. Free scan with API and MCP server | [foglift.io](https://foglift.io) |
+| **shopify-geo-audit** | Open-source CLI that audits Shopify stores for AI search readiness — scores nine weighted checks 0-100 and generates the fixes (Product JSON-LD, llms.txt, robots.txt). No signup, runs locally | [github.com/builtbyabs/shopify-geo-audit](https://github.com/builtbyabs/shopify-geo-audit) |
 
 
 ## AI Search Engines


### PR DESCRIPTION
Adds shopify-geo-audit to the AI Citation & Visibility Analytics table: an MIT-licensed CLI that audits Shopify storefronts for AI search readiness (Product JSON-LD, robots.txt AI-crawler access, llms.txt, meta/OG, content depth), scores them 0-100, and writes the actual fixes to disk. No account or API key, runs locally.