### PR TITLE
Add Bot Ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | **seoClarity** | AI-powered platform with GEO analytics module for enterprise content optimization | [seoclarity.net](https://www.seoclarity.net) |
 | **Botify** | Enterprise SEO platform with AI search readiness scoring and crawl optimization | [botify.com](https://www.botify.com) |
 | **Foglift** | AI-powered GEO readiness scanner analyzing llms.txt, structured data, crawlability, and AI search visibility. Free scan with API and MCP server | [foglift.io](https://foglift.io) |
+| **Bot Ledger** | Free directory of verified AI/LLM crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.) with a robots.txt / llms.txt generator | [farrelldan.github.io/ai-bot-directory](https://farrelldan.github.io/ai-bot-directory/) |
 
 
 ## AI Search Engines


### PR DESCRIPTION
Adds Bot Ledger (https://farrelldan.github.io/ai-bot-directory/), a free directory of verified AI/LLM crawlers (GPTBot, ClaudeBot, PerplexityBot, and others) plus a robots.txt / llms.txt generator. Placed next to Foglift under AI Citation & Visibility Analytics since both address llms.txt/crawlability readiness.