### PR TITLE
Add WeaveAI Cite to Content Optimization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | **NeuronWriter**    | NLP-based content optimization                                                                                                      | [neuronwriter.com](https://neuronwriter.com)     |
 | **Writesonic**      | AI content generation platform with AEO features.                                                                                   | [writesonic.com](https://writesonic.com)         |
 | **Answer Socrates** | Best for GEO Keyword Discovery                                                                                                      | [answersocrates.com](https://answersocrates.com) |
+| **WeaveAI Cite**    | Autonomous AEO content engine that drafts and publishes content built to earn citations in AI answers                               | [weaveai.dev](https://www.weaveai.dev/products/cite) |
 
 ### Brand Monitoring
 


### PR DESCRIPTION
Adds WeaveAI Cite to the Content Optimization Tools table, matching the existing row format.

Disclosure: I'm affiliated with WeaveAI — this is our product. Happy to adjust wording or placement if preferred.