### PR TITLE
Correct Geol.ai listing: CMS integrations are not live

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 
 | Tool               | Description                                                                                                                                     | Link                                             |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| **Geol.ai**        | First comprehensive GEO platform with automated monitoring, 50+ factor Quality Scoring Engine, and CMS integrations (WordPress, Shopify, Wix)   | [geol.ai](https://geol.ai)                       |
+| **Geol.ai**        | First comprehensive GEO platform with automated monitoring, 50+ factor Quality Scoring Engine, and 6 format-file exports you publish   | [geol.ai](https://geol.ai)                       |
 | **OptimizeGEO**    | AI search marketing intelligence platform tracking visibility score, share of voice, sentiment across AI platforms (ISO 27001, SOC 2 compliant) | [optimizegeo.ai](https://www.optimizegeo.ai)     |
 | **Conductor**      | End-to-end enterprise AEO platform, combining AEO/GEO and traditional SEO                                                                       | [conductor.com](https://www.conductor.com)       |
 | **Contently**      | Content creation, optimization, and AI visibility tracking in one system                                                                        | [contently.com](https://contently.com)           |

--- a/README_CN.md
+++ b/README_CN.md
@@ -65,7 +65,7 @@
 
 | 工具                 | 描述                                                                        | 链接                                               |
 | ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------ |
-| **Geol.ai**        | 首个综合性 GEO 平台，50+ 因素质量评分引擎，支持 WordPress、Shopify、Wix 等 CMS 集成               | [geol.ai](https://geol.ai)                       |
+| **Geol.ai**        | 首个综合性 GEO 平台，50+ 因素质量评分引擎，评分 URL 并生成 6 种格式文件供自行发布               | [geol.ai](https://geol.ai)                       |
 | **OptimizeGEO**    | AI 搜索营销智能平台，追踪可见度评分、声量份额和情感分析（ISO 27001、SOC 2 合规）                         | [optimizegeo.ai](https://www.optimizegeo.ai)     |
 | **Conductor**      | 端到端企业级 AEO 平台，结合 AEO/GEO 和传统 SEO                                          | [conductor.com](https://www.conductor.com)       |
 | **Contently**      | 集内容创作、优化和 AI 可见性追踪于一体的系统                                                  | [contently.com](https://contently.com)           |


### PR DESCRIPTION
Fixes #45.

Geol.ai scores a URL and generates 6 files the customer publishes. CMS connectors are planned, not live. There are no plugins.

Disclosure: I work on Geol.ai. This is a factual correction, not a promo rewrite.

README.md: drop WordPress/Shopify/Wix CMS claim; say 6 format-file exports you publish.
README_CN.md: same correction in Chinese.
