### PR TITLE
Add geo-check, an open source AI crawler access and readability auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | **NeuronWriter**    | NLP-based content optimization                                                                                                      | [neuronwriter.com](https://neuronwriter.com)     |
 | **Writesonic**      | AI content generation platform with AEO features.                                                                                   | [writesonic.com](https://writesonic.com)         |
 | **Answer Socrates** | Best for GEO Keyword Discovery                                                                                                      | [answersocrates.com](https://answersocrates.com) |
+| **geo-check**       | Open source CLI that scores a site's AI crawler access and readability from robots.txt, sitemap, llms.txt and sampled pages. No LLM in the scoring path | [github.com/vasco-branco06/geo-check](https://github.com/vasco-branco06/geo-check) |
 
 ### Brand Monitoring
 


### PR DESCRIPTION
geo-check audits one domain for two things: whether AI crawlers can reach it, and whether they can make sense of it once they have. It reports two scores with the exact robots.txt lines to fix what is blocked.

Adding it under Content Optimization Tools. Every entry there today is a commercial platform; this one is MIT licensed, runs locally, and calls no model, so it fills a gap rather than repeating what is already listed.

It was validated across 906 real sites, and the per site evidence is in the repository rather than asserted in a README.

https://github.com/vasco-branco06/geo-check